### PR TITLE
Removes superfluous call to compileSchema

### DIFF
--- a/src/main/scala/com/oysterbooks/scavro/plugin/AvroCodegenPlugin.scala
+++ b/src/main/scala/com/oysterbooks/scavro/plugin/AvroCodegenPlugin.scala
@@ -27,7 +27,6 @@ object AvroCodegenPlugin extends AutoPlugin {
         println("running codegen")
         val compiler = AvroCodegen(avroCodeOutputDirectory.value, file("/tmp"), showAvroCompilerOutput.value)
         compiler.run(avroIDLFiles.value, avroProtocolFiles.value, avroSchemaFiles.value)
-        compiler.compileSchema(avroSchemaFiles.value)
       },
       compile <<= (compile in Compile) dependsOn avroCodegenTask
     )


### PR DESCRIPTION
`compiler.run` calls `compiler.compileSchema`, so there isn't a need to call `compileSchema` immediately after calling `run`
